### PR TITLE
Filter events by future/past/today

### DIFF
--- a/app_rest/plugins/Results/src/Model/Table/EventsTable.php
+++ b/app_rest/plugins/Results/src/Model/Table/EventsTable.php
@@ -38,8 +38,8 @@ class EventsTable extends AppTable
      */
     public function findPaginatedEvents(array $filters): Query
     {
-        $now = new DateTime('now');
-        $now = $now->format('Y-m-d H:i:s');
+        $today = new DateTime('now');
+        $today = $today->format('Y-m-d');
 
         $query = $this->find();
 
@@ -49,18 +49,18 @@ class EventsTable extends AppTable
             // case today
             if ($when === "today") {
                 $query = $query->where([
-                    'initial_date <=' => $now,
-                    'final_date >='   => $now
+                    'initial_date <=' => $today,
+                    'final_date >='   => $today
                 ]);
             // case past
             } elseif ($when === "past") {
                 $query = $query->where([
-                    'final_date <='   => $now
+                    'final_date <='   => $today
                 ]);
             // case future
             } elseif ($when === "future") {
                 $query = $query->where([
-                    'initial_date >=' => $now,
+                    'initial_date >=' => $today,
                 ]);
             // sorry man, it was not meant to be
             } else {

--- a/app_rest/plugins/Results/src/Model/Table/EventsTable.php
+++ b/app_rest/plugins/Results/src/Model/Table/EventsTable.php
@@ -44,21 +44,21 @@ class EventsTable extends AppTable
         $query = $this->find();
 
         //Filter by ?when='today','past',future
-        if (array_key_exists("when", $filters)) {
-            $when = $filters["when"];
+        if (array_key_exists('when', $filters)) {
+            $when = $filters['when'];
             // case today
-            if ($when === "today") {
+            if ($when === 'today') {
                 $query = $query->where([
                     'initial_date <=' => $today,
-                    'final_date >='   => $today
+                    'final_date >=' => $today
                 ]);
             // case past
-            } elseif ($when === "past") {
+            } elseif ($when === 'past') {
                 $query = $query->where([
-                    'final_date <'   => $today
+                    'final_date <' => $today
                 ]);
             // case future
-            } elseif ($when === "future") {
+            } elseif ($when === 'future') {
                 $query = $query->where([
                     'initial_date >' => $today,
                 ]);

--- a/app_rest/plugins/Results/src/Model/Table/EventsTable.php
+++ b/app_rest/plugins/Results/src/Model/Table/EventsTable.php
@@ -55,12 +55,12 @@ class EventsTable extends AppTable
             // case past
             } elseif ($when === "past") {
                 $query = $query->where([
-                    'final_date <='   => $today
+                    'final_date <'   => $today
                 ]);
             // case future
             } elseif ($when === "future") {
                 $query = $query->where([
-                    'initial_date >=' => $today,
+                    'initial_date >' => $today,
                 ]);
             // sorry man, it was not meant to be
             } else {

--- a/app_rest/plugins/Results/tests/Fixture/EventsFixture.php
+++ b/app_rest/plugins/Results/tests/Fixture/EventsFixture.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Results\Test\Fixture;
 
+use DateTime;
 use RestApi\TestSuite\Fixture\RestApiFixture;
 use Results\Model\Entity\Event;
 use Results\Model\Entity\Federation;
@@ -14,26 +15,53 @@ class EventsFixture extends RestApiFixture
 
     public const FIRST_RAID = '1b10cfcc-b3f2-40bb-8dbe-8cb5d8b24c00';
 
-    public $records = [
-        [
-            'id' => Event::FIRST_EVENT,
-            'description' => 'Test Foot-o',
-            'initial_date' => '2024-01-25',
-            'final_date' => '2024-01-25',
-            'federation_id' => Federation::FEDO,
-            'created' => '2022-03-01 10:01:00',
-            'modified' => '2022-03-01 10:01:00',
-            'deleted' => null,
-        ],
-        [
-            'id' => EventsFixture::FIRST_RAID,
-            'description' => 'Test Adventure Race',
-            'initial_date' => '2024-01-26',
-            'final_date' => '2024-01-26',
+    public function init (): void
+    {
+        $this->records = [
+            [
+                'id' => Event::FIRST_EVENT,
+                'description' => 'Test Foot-o',
+                'initial_date' => '2024-01-25',
+                'final_date' => '2024-01-25',
+                'federation_id' => Federation::FEDO,
+                'created' => '2022-03-01 10:01:00',
+                'modified' => '2022-03-01 10:01:00',
+                'deleted' => null,
+            ],
+            [
+                'id' => EventsFixture::FIRST_RAID,
+                'description' => 'Test Adventure Race',
+                'initial_date' => '2024-01-26',
+                'final_date' => '2024-01-26',
+                'federation_id' => Federation::IOF,
+                'created' => '2022-03-07 10:01:00',
+                'modified' => '2022-03-07 10:01:00',
+                'deleted' => null,
+            ],
+            [
+                'id' => '1b10cfcc-b3f2-40bb-8dbe-8b24c0-today',
+                'description' => 'Today event',
+                'initial_date' => (new DateTime('now'))->format('Y-m-d'),
+                'final_date' => (new DateTime('now'))->format('Y-m-d'),
+                'federation_id' => Federation::IOF,
+                'created' => '2022-03-10 10:01:00',
+                'modified' => '2022-03-10 10:01:00',
+                'deleted' => null,
+            ],
+            [
+            'id' => '1b10cfcc-b3f2-40bb-8dbe-8b2-tomorrow',
+            'description' => 'Tomorrow event',
+            'initial_date' => (new DateTime('now'))->modify("+1 day")->format('Y-m-d'),
+            'final_date' => (new DateTime('now'))->modify("+1 day")->format('Y-m-d'),
             'federation_id' => Federation::IOF,
-            'created' => '2022-03-07 10:01:00',
-            'modified' => '2022-03-07 10:01:00',
+            'created' => '2022-03-13 10:01:00',
+            'modified' => '2022-03-13 10:01:00',
             'deleted' => null,
-        ],
-    ];
+        ]
+        ];
+
+        parent::init();
+    }
+
+
 }

--- a/app_rest/plugins/Results/tests/Fixture/EventsFixture.php
+++ b/app_rest/plugins/Results/tests/Fixture/EventsFixture.php
@@ -15,7 +15,7 @@ class EventsFixture extends RestApiFixture
 
     public const FIRST_RAID = '1b10cfcc-b3f2-40bb-8dbe-8cb5d8b24c00';
 
-    public function init (): void
+    public function init(): void
     {
         $this->records = [
             [
@@ -49,19 +49,17 @@ class EventsFixture extends RestApiFixture
                 'deleted' => null,
             ],
             [
-            'id' => '1b10cfcc-b3f2-40bb-8dbe-8b2-tomorrow',
-            'description' => 'Tomorrow event',
-            'initial_date' => (new DateTime('now'))->modify("+1 day")->format('Y-m-d'),
-            'final_date' => (new DateTime('now'))->modify("+1 day")->format('Y-m-d'),
-            'federation_id' => Federation::IOF,
-            'created' => '2022-03-13 10:01:00',
-            'modified' => '2022-03-13 10:01:00',
-            'deleted' => null,
-        ]
+                'id' => '1b10cfcc-b3f2-40bb-8dbe-8b2-tomorrow',
+                'description' => 'Tomorrow event',
+                'initial_date' => (new DateTime('now'))->modify('+1 day')->format('Y-m-d'),
+                'final_date' => (new DateTime('now'))->modify('+1 day')->format('Y-m-d'),
+                'federation_id' => Federation::IOF,
+                'created' => '2022-03-13 10:01:00',
+                'modified' => '2022-03-13 10:01:00',
+                'deleted' => null,
+            ]
         ];
 
         parent::init();
     }
-
-
 }

--- a/app_rest/plugins/Results/tests/TestCase/Controller/EventsControllerTest.php
+++ b/app_rest/plugins/Results/tests/TestCase/Controller/EventsControllerTest.php
@@ -73,13 +73,13 @@ class EventsControllerTest extends ApiCommonErrorsTest
             ]
         ];
 
-        $this->assertEquals($expected,$bodyDecoded["data"][0]);
+        $this->assertEquals($expected, $bodyDecoded['data'][0]);
     }
 
     public function testGetList_paginated_WhenFuture()
     {
         $this->get($this->_getEndpoint() . '?when=future');
-        $tomorrow = (new DateTime('now'))->modify("+1 day")->format('Y-m-d');
+        $tomorrow = (new DateTime('now'))->modify('+1 day')->format('Y-m-d');
 
         $bodyDecoded = $this->assertJsonResponseOK();
         $expected = [
@@ -94,7 +94,7 @@ class EventsControllerTest extends ApiCommonErrorsTest
                 'self' => 'http://dev.example.com/api/v1/events/1b10cfcc-b3f2-40bb-8dbe-8b2-tomorrow'
             ]
         ];
-        $this->assertEquals($expected,$bodyDecoded["data"][0]);
+        $this->assertEquals($expected, $bodyDecoded['data'][0]);
     }
 
     public function testGetList_paginated_WhenPast()
@@ -102,7 +102,7 @@ class EventsControllerTest extends ApiCommonErrorsTest
         $this->get($this->_getEndpoint() . '?when=past&page=2&limit=1');
 
         $bodyDecoded = $this->assertJsonResponseOK();
-        $this->assertEquals($this->_getSecondEvent(),$bodyDecoded["data"][0]);
+        $this->assertEquals($this->_getSecondEvent(), $bodyDecoded['data'][0]);
     }
 
     public function testGetData()

--- a/app_rest/plugins/Results/tests/TestCase/Controller/EventsControllerTest.php
+++ b/app_rest/plugins/Results/tests/TestCase/Controller/EventsControllerTest.php
@@ -40,7 +40,7 @@ class EventsControllerTest extends ApiCommonErrorsTest
         $this->get($this->_getEndpoint());
 
         $bodyDecoded = $this->assertJsonResponseOK();
-        $this->assertEquals(2, count($bodyDecoded['data']));
+        $this->assertEquals(4, count($bodyDecoded['data']));
         $this->assertEquals($this->_getFirstEvent(), $bodyDecoded['data'][0]);
         $this->assertEquals($this->_getSecondEvent(), $bodyDecoded['data'][1]);
     }


### PR DESCRIPTION
The parameter `?when` has been added to the events contoller. Possible values are: `past`, `today` and `future`. If a different value is provided a `BadRequestExecption` is thrown.